### PR TITLE
added mapping for CSV export from DKB

### DIFF
--- a/src/app/money/transactions/form-import/mappings.ts
+++ b/src/app/money/transactions/form-import/mappings.ts
@@ -52,6 +52,14 @@ export const MAPPINGS_BY_FORMAT: { [format: string]: FormatMapping } = {
       return absAmount;
     })
     .build(),
+  'dkb': new FormatMappingBuilder<DkbRow>()
+    .addConstantMapping("isCash", false)
+    .addMapping("date", "Wertstellung", parseDate)
+    .addMapping("reason", "Verwendungszweck", input => input.replace('\n', ''))
+    .addMapping("who", "Auftraggeber / Begünstigter")
+    .addMapping("whoIdentifier", "Kontonummer")
+    .addRawMapping("amount", "Betrag (EUR)", parseAmount)
+    .build(),
 };
 
 const dateRegex = /^(\d\d)\.(\d\d)\.(\d\d(?:\d\d)?)$/;
@@ -127,4 +135,18 @@ interface MlpRow {
   "Währung": string;
   "Umsatz": string;
   " ": string;
+}
+
+interface DkbRow {
+  "Buchungstag": string;
+  "Wertstellung": string;
+  "Buchungstext": string;
+  "Auftraggeber / Begünstigter": string;
+  "Verwendungszweck": string;
+  "Kontonummer": string;
+  "BLZ": string;
+  "Betrag (EUR)": string;
+  "Gläubiger-ID": string;
+  "Mandatsreferenz": string;
+  "Kundenreferenz": string;
 }


### PR DESCRIPTION
I quickly added the mappings for the CSV export file from the bank DKB. Since I don't run the finance-tracker this is completly untested.
Would be really nice if you could test this. Thanks!

[DKB-sample-export.zip](https://github.com/Bone008/finance-tracker/files/3311881/DKB-sample-export.zip)
